### PR TITLE
Fix dom class bug on items

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,16 +157,16 @@ The gem has no default styling, but leaves that up to you.
 For reference, here's an example markup:
 
 ```html
-<div class="simple_form_nested_fields simple_form_nested_fields__texts">
+<div class="simple_form_nested_fields simple_form_nested_fields--texts">
   <div class="simple_form_nested_fields__title">Texts</div>
   <div class="simple_form_nested_fields__items">
-    <div class="simple_form_nested_fields__item simple_form_nested_fields__item__new">
-      <!-- input fields here -->
-      <a class="simple_form_nested_fields__link simple_form_nested_fields__link__remove">Remove</a>
+    <div class="simple_form_nested_fields__item simple_form_nested_fields__item--new">
+      <!-- fields -->
+      <a class="simple_form_nested_fields__link simple_form_nested_fields__link--remove">Remove</a>
     </div>
   </div>
   <div class="simple_form_nested_fields__links">
-    <a class="simple_form_nested_fields__link simple_form_nested_fields__link__add">Add Title</a>
+    <a class="simple_form_nested_fields__link simple_form_nested_fields__link--add">Add Title</a>
   </div>
 </div>
 ```

--- a/lib/assets/javascripts/simple_form_nested_fields.coffee
+++ b/lib/assets/javascripts/simple_form_nested_fields.coffee
@@ -22,7 +22,7 @@ do ($ = jQuery, window, document) ->
       @$element.data('plugin_SimpleFormNestedFields__Links').destroy()
       @$element.data('plugin_SimpleFormNestedFields__Sortable').destroy()
 
-    is_sortable: -> @element.classList.contains('simple_form_nested_fields__sortable')
+    is_sortable: -> @element.classList.contains('simple_form_nested_fields--sortable')
 
   # A really lightweight plugin wrapper around the constructor,
   # preventing against multiple instantiations

--- a/lib/assets/javascripts/simple_form_nested_fields__links.coffee
+++ b/lib/assets/javascripts/simple_form_nested_fields__links.coffee
@@ -2,7 +2,7 @@ do ($ = jQuery, window, document) ->
   pluginName = 'SimpleFormNestedFields__Links'
   defaults =
     debug: false
-    new_item_class_name: 'simple_form_nested_fields__item__new'
+    new_item_class_name: 'simple_form_nested_fields__item--new'
     regexp: new RegExp("__INDEX_PLACEHOLDER__", 'g')
 
   class Plugin
@@ -18,11 +18,11 @@ do ($ = jQuery, window, document) ->
         e.preventDefault()
         link = e.target
         switch
-          when link.classList.contains('simple_form_nested_fields__link__add') then @add_new_item(link)
-          when link.classList.contains('simple_form_nested_fields__link__remove') then @remove_item(link)
+          when link.classList.contains('simple_form_nested_fields__link--add') then @add_new_item(link)
+          when link.classList.contains('simple_form_nested_fields__link--remove') then @remove_item(link)
 
     destroy: ->
-      @$element.off "click.#{@_name}", '.simple_form_nested_fields__link__add'
+      @$element.off "click.#{@_name}", '.simple_form_nested_fields__link--add'
 
     get_index: -> new Date().getTime()
     get_template: (link) -> $(link).data('template').replace(@options.regexp, @get_index())

--- a/lib/simple_form_nested_fields.rb
+++ b/lib/simple_form_nested_fields.rb
@@ -4,6 +4,8 @@ require 'rails'
 
 require 'simple_form_nested_fields/version'
 
+require 'simple_form_nested_fields/bem'
+
 require 'simple_form_nested_fields/action_view_extension'
 require 'simple_form_nested_fields/nested_fields_builder'
 require 'simple_form_nested_fields/railtie' if defined?(Rails)

--- a/lib/simple_form_nested_fields/bem.rb
+++ b/lib/simple_form_nested_fields/bem.rb
@@ -1,0 +1,52 @@
+module SimpleFormNestedFields
+  class Bem
+    E_PREFIX = '__'.freeze
+    M_PREFIX = '--'.freeze
+
+    # Bem.new(b: :simple_form_nested_fields, e: :items, m: :open).to_s
+    # => "simple_form_nested_fields__items simple_form_nested_fields__items--open"
+    def initialize(b: nil, e: nil, m: nil)
+      @b = b
+      @e = e
+      @m = m
+    end
+
+    def to_s
+      [b_class, e_class, m_classes].uniq.reject(&:blank?).join(' ')
+    end
+
+    private
+    attr_reader :b, :e, :m
+
+    def bem_classes
+      [b_class, e_class, m_classes].uniq
+    end
+
+    def b_class
+      return unless b.present?
+      return if e.present?
+      b.to_s
+    end
+
+    def e_class
+      return unless e.present?
+      [b.to_s, em_class_builder(e, E_PREFIX)].reject(&:blank?).join
+    end
+
+    def m_classes
+      return unless m.present?
+      [m].flatten.map do |modifier|
+        [
+          b.to_s,
+          em_class_builder(e, E_PREFIX),
+          em_class_builder(modifier, M_PREFIX)
+        ].reject(&:blank?).join
+      end
+    end
+
+    def em_class_builder(em, prefix)
+      return unless em.present?
+      "#{prefix}#{em.to_s}"
+    end
+  end
+end

--- a/lib/simple_form_nested_fields/nested_fields_builder.rb
+++ b/lib/simple_form_nested_fields/nested_fields_builder.rb
@@ -111,10 +111,7 @@ module SimpleFormNestedFields
     end
 
     def bem_class(e: nil, m: nil)
-      res = [BASE_DOM_CLASS]
-      res << "__#{e}" if e.present?
-      res << "__#{m}" if m.present?
-      res.join
+      SimpleFormNestedFields::Bem.new(b: BASE_DOM_CLASS, e: e, m: m).to_s
     end
   end
 end

--- a/test/integration/nested_fields_test.rb
+++ b/test/integration/nested_fields_test.rb
@@ -5,21 +5,21 @@ describe 'Nested Fields', :capybara do
 
   describe 'items' do
     it 'does not have any items to begin with' do
-      page.wont_have_selector '.simple_form_nested_fields__item__new'
+      page.wont_have_selector '.simple_form_nested_fields__item--new'
     end
 
     describe 'adding and removing' do
       let(:body) { 'Foo bar' }
 
-      before { within(:css, '.simple_form_nested_fields__titles') { add_item } }
+      before { within(:css, '.simple_form_nested_fields--titles') { add_item } }
 
       it 'adds an item when clicking the add link', js: true do
-        page.must_have_selector '.simple_form_nested_fields__item__new'
+        page.must_have_selector '.simple_form_nested_fields__item--new'
       end
 
       it 'removes an item when clicking the remove link', js: true do
         remove_item
-        page.wont_have_selector '.simple_form_nested_fields__item__new'
+        page.wont_have_selector '.simple_form_nested_fields__item--new'
       end
 
       it 'allows to store the document', js: true do
@@ -32,7 +32,7 @@ describe 'Nested Fields', :capybara do
     describe 'sortable' do
       before do
         (1..3).each do |index|
-          within(:css, '.simple_form_nested_fields__texts') do
+          within(:css, '.simple_form_nested_fields--texts') do
             add_item
 
             within(:css, ".simple_form_nested_fields__item:nth-child(#{index})") do
@@ -60,11 +60,11 @@ describe 'Nested Fields', :capybara do
   private
 
   def add_item
-    find(:css, '.simple_form_nested_fields__link__add').click
+    find(:css, '.simple_form_nested_fields__link--add').click
   end
 
   def remove_item
-    find(:css, '.simple_form_nested_fields__link__remove').click
+    find(:css, '.simple_form_nested_fields__link--remove').click
   end
 
   def submit_form

--- a/test/simple_form_nested_fields/bem_test.rb
+++ b/test/simple_form_nested_fields/bem_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+describe SimpleFormNestedFields::Bem do
+  subject { SimpleFormNestedFields::Bem }
+
+  it 'builds a bem style selector string' do
+    subject.new(b: :text_block).to_s.must_equal 'text_block'
+    subject.new(b: :text_block, e: :element).to_s.must_equal 'text_block__element'
+    subject.new(b: :text_block, m: :modifier).to_s.must_equal 'text_block text_block--modifier'
+    subject.new(b: :text_block, e: :element, m: :modifier).to_s.must_equal 'text_block__element text_block__element--modifier'
+    subject.new(b: :text_block, m: [:modifier_one, :modifier_two]).to_s.must_equal 'text_block text_block--modifier_one text_block--modifier_two'
+    subject.new(b: :text_block, e: :element, m: [:modifier_one, :modifier_two]).to_s.must_equal 'text_block__element text_block__element--modifier_one text_block__element--modifier_two'
+  end
+end

--- a/test/simple_form_nested_fields/nested_fields_builder_test.rb
+++ b/test/simple_form_nested_fields/nested_fields_builder_test.rb
@@ -19,12 +19,12 @@ class SimpleFormNestedFields::NestedFieldsBuilderTest < ActionView::TestCase
 
     it { nested_fields.must_match(/simple_form_nested_fields__title/) }
     it { nested_fields.must_match(/simple_form_nested_fields__items/) }
-    it { nested_fields.must_match(/simple_form_nested_fields__link__add/) }
+    it { nested_fields.must_match(/simple_form_nested_fields__link--add/) }
 
     describe 'sortable' do
       let(:options) { { sortable: true } }
 
-      it { nested_fields.must_match(/simple_form_nested_fields__sortable/) }
+      it { nested_fields.must_match(/simple_form_nested_fields--sortable/) }
     end
 
     describe 'with items' do


### PR DESCRIPTION
This PR fixes a bug with the dom classes generated for nested items. It adds a `Bem` helper class, which takes care of generating the dom classes, which are now more in line with the official bem guidelines.

This change means the selectors for add and remove links had to be updated in the javascript files and any styling in the apps using this gem has to be amended. The add and remove links previously had the following classes:

```RUBY
["simple_form_nested_fields__link__add"] # for the add link
["simple_form_nested_fields__link__remove"] # for the remove link
```

and now have:

```RUBY
["simple_form_nested_fields__link", "simple_form_nested_fields__link--add"] # for the add link
["simple_form_nested_fields__link", "simple_form_nested_fields__link--remove"] # for the remove link
```

Likewise the sortable class is changed from `simple_form_nested_fields__sortable` to `simple_form_nested_fields--sortable`.

I have not updated the package js, as I'm not totally clear how these are built, but the change should be very easy to make.